### PR TITLE
Fix robots sitemap URL

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /404
 Disallow: /confirmation
-Sitemap: https://alize-waron.netlify.app//sitemap.xml
+Sitemap: https://alize-waron.netlify.app/sitemap.xml


### PR DESCRIPTION
## Summary
- correct sitemap path in `public/robots.txt`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401b732e948323a51e9d88a2f96473